### PR TITLE
Update link to repository README

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ Learners are expected to have the following knowledge:
 ## We can help you out with teaching this lesson
 
 Do you want to teach this lesson?
-Find more help in the [README](https://github.com/carpentries-incubator/deep-learning-intro?tab=readme-ov-file#teaching-this-lesson)
+Find more help in the [README](https://github.com/carpentries-lab/deep-learning-intro?tab=readme-ov-file#teaching-this-lesson)
 Feel free to reach out to us with any questions that you have.
 Just open a new issue.
 We also value any feedback on the lesson!


### PR DESCRIPTION
I noticed while browsing the [_Summary and Schedule_ / index page in the instructor view](https://carpentries-lab.github.io/deep-learning-intro/instructor/index.html) that the link to the repository README in the 'We can help you out with teaching this lesson' expandable points to the repository in the `carpentries-incubator` organization rather than the current `carpentries-lab` and so is broken. This PR just updates the URL to go to the correct README file.

Thanks to everyone who has contributed to such a great set of lesson material 😄!