### PR TITLE
548 set random seeds in episode 3 4 5

### DIFF
--- a/episodes/2-keras.md
+++ b/episodes/2-keras.md
@@ -316,8 +316,6 @@ For this episode it is useful if everyone gets the same results from their train
 Keras uses a random number generator at certain points during its execution.
 Therefore we will need to set two random seeds, one for numpy and one for tensorflow:
 ```python
-from numpy.random import seed
-seed(1)
 keras.utils.set_random_seed(2)
 ```
 

--- a/episodes/3-monitor-the-model.md
+++ b/episodes/3-monitor-the-model.md
@@ -197,6 +197,7 @@ We compose a network of two hidden layers to start off with something. We go by 
 
 ```python
 from tensorflow import keras
+keras.utils.set_random_seed(2)
 
 def create_nn(input_shape):
     # Input layer

--- a/episodes/4-advanced-layer-types.md
+++ b/episodes/4-advanced-layer-types.md
@@ -279,6 +279,7 @@ So let us look at a network with a few convolutional layers. We need to finish w
 
 ```python
 from tensorflow import keras
+keras.utils.set_random_seed(2)
 
 inputs = keras.Input(shape=train_images.shape[1:])
 x = keras.layers.Conv2D(50, (3, 3), activation='relu')(inputs)

--- a/episodes/5-transfer-learning.md
+++ b/episodes/5-transfer-learning.md
@@ -65,6 +65,8 @@ Let's define our model input layer using the shape of our training images:
 ```python
 # input tensor
 from tensorflow import keras
+keras.utils.set_random_seed(2)
+
 inputs = keras.Input(train_images.shape[1:])
 ```
 


### PR DESCRIPTION
Added the `keras.utils.set_random_seed(2)` line in episodes 4,5 and 6. To be consistent, I also deleted the numpy seed() line from episode 2. According to [keras docs](https://keras.io/examples/keras_recipes/reproducibility_recipes/) the `keras.utils.set_random_seed()` internally fixes the numpy seed as well.

