### PR TITLE
define DOI as identifier in CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ title: Introduction to deep learning
 message: Learn deep learning with Python
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.8308392
+    value: 10.5281/zenodo.8308391
 type: software
 authors:
   - given-names: Sven


### PR DESCRIPTION
Closes #615 

I think this is the expected syntax for providing a DOI in the CFF, and should fix the current problem with the lesson build.