### PR TITLE
Add venv directories to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ renv/sandbox # OPTIONAL
 **/.DS_Store
 .ipynb_checkpoints
 
+.venv/
+venv/


### PR DESCRIPTION
Add `.venv/` and `venv` to `.gitignore` to prevent accidental commits.
