### PR TITLE
Add JOSE DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/carpentries-lab/deep-learning-intro/scaffolds)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8308391.svg)](https://doi.org/10.5281/zenodo.8308391)
+[![DOI](https://jose.theoj.org/papers/10.21105/jose.00307/status.svg)](https://doi.org/10.21105/jose.00307)
 [![The Carpentries Lab Review Status](http://badges.carpentries-lab.org/25_status.svg)](https://github.com/carpentries-lab/reviews/issues/25)
 
 # Introduction to deep learning

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@
 # cp: Carpentries (to use for instructor training for instance)
 # incubator: The Carpentries Incubator
 carpentry: 'lab'
-doi: 'https://doi.org/10.5281/zenodo.8308391'
+doi: 'https://doi.org/10.21105/jose.00307'
 
 # Overall title for pages.
 title: 'Introduction to deep learning'


### PR DESCRIPTION
Now that [the paper has been published in JOSE](https://github.com/openjournals/jose-reviews/issues/307#issuecomment-3705830774) I think we should use their DOI instead of the Zenodo entry. This PR updates the config file and README accordingly.

Congratulations @carschno and everyone else!